### PR TITLE
build: add build and prepublish scripts for sequential package building

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "dev:vue": "bpkg run dev -f apps/vue",
     "build:packages": "bpkg run build -f packages/*",
     "build:react": "bpkg run build -f apps/react",
+    "build": "bpkg run build -f packages/* --sequential",
+    "prepublish": "bpkg run prepublish -f packages/* --sequential",
     "format": "bpkg run format -f apps/* packages/* && git add --renormalize .",
     "lint": "bpkg run lint",
     "test": "rimraf apps/react/public/coverage && vitest --run",


### PR DESCRIPTION
- Add 'build' script to run sequential build for all packages
- Add 'prepublish' script to run sequential prepublish for all packages
- These changes prepare for enabling publish via GitHub CLI